### PR TITLE
fixed table sorting and removed moment

### DIFF
--- a/src/pages/FileManagePage/FileManagePage.tsx
+++ b/src/pages/FileManagePage/FileManagePage.tsx
@@ -172,7 +172,6 @@ const FileManagePage = ({ history }) => {
   const [isFilechoosed, setIsFileChoosed] = React.useState(true);
   const [, setProcessChange] = React.useState();
   const [currentUploader, setCurrentUploader] = React.useState<OpaqueUpload>();
-  //const [searchname, SetSearchname] = React.useState("");
 
   const handleShowSidebar = React.useCallback(() => {
     setShowSidebar(!showSidebar);

--- a/src/pages/FileManagePage/FileManagePage.tsx
+++ b/src/pages/FileManagePage/FileManagePage.tsx
@@ -272,6 +272,8 @@ const FileManagePage = ({ history }) => {
         setFileList(folderMeta.files);
         setCurrentLocation(folderMeta.location);
         loadingFlagCnt--;
+        await getFolderMetaList(folders);
+        await getFileMetaList(folderMeta.files);
         loadingFlagCnt === 0 && setPageLoading(false);
       })
       .catch((err) => {
@@ -324,8 +326,10 @@ const FileManagePage = ({ history }) => {
 
       const usedStorage = accountInfo.account.storageUsed;
       const limitStorage = accountInfo.account.storageLimit;
-      const remainDays = moment(accountInfo.account.expirationDate).diff(moment(Date.now()), "days");
-
+      const remainDays = differenceInDays(
+        new Date(accountInfo.account.expirationDate),
+        new Date()
+      );
       const plansApi = await account.plans();
       let idx = 0;
       for (idx = 0; idx < plansApi.length; idx++) {
@@ -1110,13 +1114,6 @@ const FileManagePage = ({ history }) => {
     if (selectedFiles.length) {
       setSelectedFiles([]);
     } else {
-      let fileMetaValues = fileMetaList;
-
-      if (!fileMetaList) {
-        await getFolderMetaList();
-        fileMetaValues = await getFileMetaList();
-      }
-
       setSelectedFiles(fileMetaValues.filter((item) => "uploaded" in item));
     }
   };
@@ -1175,8 +1172,8 @@ const FileManagePage = ({ history }) => {
     const Ameta = sourceList.find((meta) => bytesToHex(meta.location) === bytesToHex(a.location));
     const Bmeta = sourceList.find((meta) => bytesToHex(meta.location) === bytesToHex(b.location));
 
-    var nameA = type === "file" ? (Ameta?.public?.location ? "PUBLIC" : "PRIVATE") : Ameta.path.toUpperCase();
-    var nameB = type === "file" ? (Bmeta?.public?.location ? "PUBLIC" : "PRIVATE") : Bmeta.path.toUpperCase();
+    var nameA = type === "file" ? (Ameta.public.location ? "PUBLIC" : "PRIVATE") : Ameta.path.toUpperCase();
+    var nameB = type === "file" ? (Bmeta.public.location ? "PUBLIC" : "PRIVATE") : Bmeta.path.toUpperCase();
     if (nameA < nameB) {
       return mode === "down" ? 1 : -1;
     }
@@ -1214,7 +1211,7 @@ const FileManagePage = ({ history }) => {
     return 0;
   };
 
-  const getFileMetaList = React.useCallback(async () => {
+  const getFileMetaList = async (fileList: FolderFileEntry[]) => {
     setPageLoading(true);
     loadingFlagCnt++;
     const metaList = fileList.map(async (file) => {
@@ -1232,9 +1229,9 @@ const FileManagePage = ({ history }) => {
     loadingFlagCnt--;
     loadingFlagCnt === 0 && setPageLoading(false);
     return tmp;
-  }, [fileList]);
+  }
 
-  const getFolderMetaList = React.useCallback(async () => {
+  const getFolderMetaList = async (folderList: FoldersIndexEntry[]) => {
     setPageLoading(true);
     loadingFlagCnt++;
     const metaList = folderList.map(async (folder) => {
@@ -1251,7 +1248,7 @@ const FileManagePage = ({ history }) => {
     setFolderMetaList(tmp);
     loadingFlagCnt--;
     loadingFlagCnt === 0 && setPageLoading(false);
-  }, [folderList]);
+  }
 
   React.useEffect(() => {
     if (folderMetaList && fileMetaList && sortable.column !== "null") {

--- a/src/pages/FileManagePage/FileManagePage.tsx
+++ b/src/pages/FileManagePage/FileManagePage.tsx
@@ -172,6 +172,7 @@ const FileManagePage = ({ history }) => {
   const [isFilechoosed, setIsFileChoosed] = React.useState(true);
   const [, setProcessChange] = React.useState();
   const [currentUploader, setCurrentUploader] = React.useState<OpaqueUpload>();
+  //const [searchname, SetSearchname] = React.useState("");
 
   const handleShowSidebar = React.useCallback(() => {
     setShowSidebar(!showSidebar);
@@ -1138,7 +1139,7 @@ const FileManagePage = ({ history }) => {
       setFolderList(fileterfolderList);
     } else {
       toast.info("Search string empty!!");
-      setUpdateCurrentFolderSwitch(!updateCurrentFolderSwitch);
+      //setUpdateCurrentFolderSwitch(!updateCurrentFolderSwitch);
     }
   };
   const getSelectedFileSize = () => {


### PR DESCRIPTION
### Description

This includes the fixes for sorting of the table.

### Solution

The problem was the `fileMetaList` and `folderMetaList` where not getting updated whenever we upload new file.
So whenever the uploader queue is empty, we fetch and reset the state.

### Test Cases

### Devices

Chrome version 101.0.4951.64

### Screenshots/GIF
<img width="1316" alt="Screenshot 2022-05-19 at 2 28 37 PM" src="https://user-images.githubusercontent.com/73488057/169255182-157b807f-c105-4d8f-8444-b6629c8f7ced.png">
